### PR TITLE
Automate new releases.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    # Limit this action to tags only
+    tags:
+      - 'v[0-9]+\.[0-9]+\.[0-9]+'
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Yarn setup
+        uses: DerYeger/yarn-setup-action@master
+        with:
+          node-version: 16
+      - name: Release
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          touch .npmrc
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
+          RELEASE_VERSION=${GITHUB_REF#refs/*/v}
+          npm --no-git-tag-version version $RELEASE_VERSION
+          npm publish

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 #### An ESLint [Shareable Config][shareable-configs-url]
 
+## Deployment
+
+Create a new annotated tag and push it to github.
+
+```sh
+git tag -a v1.0.0 -m "Tag comment"
+git push origin v1.0.0
+```
+
 ## Installation
 
 ```sh


### PR DESCRIPTION
Gitlab action to automatically publish new version on npm when a new tag is created.

Automation token with name `NPM_TOKEN` was added to project secrets by @davidkuridza 

Failed pipeline can be inspected [here](https://github.com/3fs/eslint-config/actions/runs/1489500970). Pipeline failed because it ran on a commit instead of a tag. 