### PR TITLE
frontend: Update angular rules

### DIFF
--- a/configs/angular.js
+++ b/configs/angular.js
@@ -187,7 +187,8 @@ module.exports = {
             "imports": "always-multiline",
             "exports": "always-multiline",
             "enums": "always-multiline",
-            "functions": "ignore"
+            "functions": "ignore",
+            "generics": "always-multiline"
           }
         ],
         "@typescript-eslint/no-extraneous-class": "off",


### PR DESCRIPTION
Update eslint for angular rules ... 

We would like to add `"generics": "always-multiline"` line to  this lint rule: 

```
     "@typescript-eslint/comma-dangle": [
          "error",
          {             "arrays": "always-multiline",
            "objects": "always-multiline",
            "imports": "always-multiline",
            "exports": "always-multiline",
            "enums": "always-multiline",
            "functions": "ignore" 
}
```

Is that acceptable?
